### PR TITLE
update answer to last ice age from DDG

### DIFF
--- a/test/behave/qanda.feature
+++ b/test/behave/qanda.feature
@@ -28,11 +28,11 @@ Feature: Question and Answer functionality
      When the user says "<when did this happen>"
      Then mycroft reply should contain "<time>"
 
-  Examples: what questions
+  Examples: when questions
     | when did this happen | time |
     | when was alexander the great born | 356 |
     | when will the sun die | billion |
-    | when was the last ice age | glacial |
+    | when was the last ice age | after the Medieval Warm Period |
 
   Scenario Outline: user asks where something is
    Given an english speaking user


### PR DESCRIPTION
Current failing test case: "when was the last ice age"

DDG API has started returning a different first result about a more recent "little ice age" rather than the last major "glacial" ice age it previously returned.

This is a quick fix. Or we could add / modify the Step so that we can test for a if a response contains X or Y.