### PR TITLE
Restore Wolfram Alpha tests and ensure measurement unit is imperial

### DIFF
--- a/test/behave/qanda.feature
+++ b/test/behave/qanda.feature
@@ -9,22 +9,9 @@ Feature: Question and Answer functionality
     | who is a person | person |
     | who is george church | church |
     | who are the foo fighters | foo |
-
-  @xfail
-  Scenario Outline: who questions failing due to Wolfram API outage
-    Given an english speaking user
-     When the user says "<failing wolfram query>"
-     Then mycroft resply should contain "<expected answer>"
-
-  Examples: failing wolfram questions
-    | failing wolfram query | expected answer |
     | who built the eiffel tower | sauvestre |
     | who wrote the book outliers | gladwell |
     | who discovered helium | janssen |
-    | what is the melting point of aluminum | 660 |
-    | when was alexander the great born | 356 |
-    | when will the sun die | billion |
-
 
   Scenario Outline: user asks a what question
     Given an english speaking user
@@ -34,6 +21,7 @@ Feature: Question and Answer functionality
   Examples: what questions
     | what is a thing | thing |
     | what is metallurgy | metallurgy |
+    | what is the melting point of aluminum | 660 |
 
   Scenario Outline: user asks when something is
     Given an english speaking user
@@ -43,9 +31,10 @@ Feature: Question and Answer functionality
   Examples: when questions
     | when did this happen | time |
     | when was the last ice age | after the Medieval Warm Period |
+    | when was alexander the great born | 356 |
+    | when will the sun die | billion |
 
-  @xfail
-  Scenario Outline: user asks where something is - failing due to Wolfram API outage
+  Scenario Outline: user asks where something is
    Given an english speaking user
     When the user says "<where is a place>"
     Then mycroft reply should contain "<place>"
@@ -56,9 +45,9 @@ Feature: Question and Answer functionality
     | where is saturn | saturn |
     | where is the smithsonian | washington |
 
-  @xfail
-  Scenario Outline: user asks a how question - failing due to Wolfram API outage
+  Scenario Outline: user asks a how question
     Given an english speaking user
+      And the user's unit system is imperial
      When the user says "<how is this a thing>"
      Then mycroft reply should contain "<the answer>"
 


### PR DESCRIPTION
Restores the Wolfram Alpha tests as the API key has been restored.

Also ensures the unit of measurement configuration is set for the eiffel tower query that is expecting a response in feet. This won't affect the CI but would fail on most local machines as the majority of the world use metric...